### PR TITLE
Dog Profile 수정시 중복되어서 저장되는 문제

### DIFF
--- a/src/main/java/com/kakaoseventeen/dogwalking/dog/domain/Dog.java
+++ b/src/main/java/com/kakaoseventeen/dogwalking/dog/domain/Dog.java
@@ -57,15 +57,15 @@ public class Dog {
             this.image = imageUrl;
         }
 
-        if (!dogReqDTO.getName().isEmpty()){
+        if (dogReqDTO.getName() != null && !dogReqDTO.getName().isEmpty()){
             this.name = dogReqDTO.getName();
         }
 
-        if (!dogReqDTO.getSex().isEmpty()){
+        if (dogReqDTO.getSex() != null && !dogReqDTO.getSex().isEmpty()){
             this.sex = dogReqDTO.getSex();
         }
 
-        if (!dogReqDTO.getBreed().isEmpty()){
+        if (dogReqDTO.getBreed() != null && !dogReqDTO.getBreed().isEmpty()){
             this.breed = dogReqDTO.getBreed();
         }
 
@@ -73,11 +73,11 @@ public class Dog {
             this.age = Integer.parseInt(dogReqDTO.getAge());
         }
 
-        if (!dogReqDTO.getSize().isEmpty()){
+        if (dogReqDTO.getSize() != null && !dogReqDTO.getSize().isEmpty()){
             this.size = dogReqDTO.getSize();
         }
 
-        if (!dogReqDTO.getSpecificity().isEmpty()){
+        if (dogReqDTO.getSpecificity() != null && !dogReqDTO.getSpecificity().isEmpty()){
             this.specificity = dogReqDTO.getSpecificity();
         }
     }

--- a/src/main/java/com/kakaoseventeen/dogwalking/member/domain/Member.java
+++ b/src/main/java/com/kakaoseventeen/dogwalking/member/domain/Member.java
@@ -51,7 +51,7 @@ public class Member {
         if (profileImage != null) {
             this.profileImage = profileImage;
         }
-        if (!profileContent.isEmpty()) {
+        if (profileContent != null && !profileContent.isEmpty()) {
             this.profileContent = profileContent;
         }
     }


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 내용

- Dog Profile 수정시 중복되어서 저장되는 문제
- 기존 Profile Update Request DTO에 있던 문자열을 isEmpty()로만 체킹 했던 코드를 null 체킹도 동시에 진행
- isEmpty() : null인 문자열 객체에 접근시 NPE가 발생한다.

close #278 
